### PR TITLE
feat: adds support for projecting polygons

### DIFF
--- a/src/sql.js
+++ b/src/sql.js
@@ -51,7 +51,18 @@ sql.fn.esriGeom = function (geometry) {
 
 sql.fn.project = function (geometry, projection) {
   if (geometry && geometry.coordinates) {
-    const coordinates = proj4(projection).forward(geometry.coordinates)
+    var coordinates;
+    
+    if (geometry.type === 'Polygon') {
+        //unbox and convert each coord
+        var convert = geometry.coordinates[0].map(function(coord) {
+          return proj4(projection).forward(coord);
+        });
+        // rebox
+        coordinates = [convert]
+    } else {
+        coordinates = proj4(projection).forward(geometry.coordinates)
+    }
     return {
       type: geometry.type,
       coordinates

--- a/test/fixtures/polygon.json
+++ b/test/fixtures/polygon.json
@@ -1,4 +1,4 @@
-module.exports = {
+{
     "type": "FeatureCollection",
     "features": [
       {

--- a/test/project.js
+++ b/test/project.js
@@ -2,6 +2,7 @@
 const test = require('tape')
 const winnow = require('../src')
 const features = require('./fixtures/snow.json').features
+const polygonFeatures = require('./fixtures/polygon.json').features
 
 test('Project to Web Mercator using 3857', t => {
   t.plan(2)
@@ -25,6 +26,28 @@ test('Project to Web Mercator using 3857 and translating to esri', t => {
   t.equal(results.length, 1)
   t.equal(results[0].geometry.x, -11682713.391976157)
   t.equal(results[0].geometry.y, 4857924.005275469)
+})
+
+test('Project a polygon to Web Mercator using 3857 and translating to esri', t => {
+  t.plan(2)
+  const options = {
+    projection: 3857,
+    limit: 1,
+    toEsri: true
+  }
+  const results = winnow.query(polygonFeatures, options)
+
+  t.equal(results.length, 1)
+  t.deepEqual(results[0].geometry.rings, [ 
+    [
+      [ -13247454.246160466, 6496535.908013698 ],
+      [ -11408073.597505985, 6985732.8890388245 ],
+      [ -9216471.12251341, 4813698.293287256 ],
+      [ -10214432.963804673, 3874440.0897190133 ],
+      [ -12934368.178304385, 3424378.867175897 ],
+      [ -13247454.246160466, 6496535.908013698 ] 
+    ] 
+  ])
 })
 
 test('Project to Web Mercator using 3857 with an esri style outSR', t => {


### PR DESCRIPTION
proj4 only takes a single coordinate at a time.  This will pull out the plygons coordinates and convert them one by one.