### PR TITLE
Fix/readme sql naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### unreleased
+* correct typo: winnow.sql => winnow.querySql
+
 ## [1.10.2] - 06-20-2017
 ### Fixed
 - Do not overwrite existing OID

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ filter(geojson)
 // returns the set of feature that match the query
 ```
 
-## `winnow.sql`
+## `winnow.querySql`
 Execute sql directly against the query engine.
 
 - Replace any variables with ?
@@ -165,7 +165,7 @@ Execute sql directly against the query engine.
  const statement = 'Select * from ? where Genus in ?'
  const data = geojson
  const genus = ['Quercus']
- winnow.sql(statement, [geojson, genus])
+ winnow.querySql(statement, [geojson, genus])
  // returns all features that match the query
  ```
 


### PR DESCRIPTION
not sure if this is a typo, but it seems winnow exposes .querySql, not .sql