### PR TITLE
fix: adds IS command for null searching

### DIFF
--- a/src/where.js
+++ b/src/where.js
@@ -1,4 +1,4 @@
-const OPERATORS = ['>', '<', '=', '>=', '<=', 'like', 'ilike', 'in']
+const OPERATORS = ['>', '<', '=', '>=', '<=', 'like', 'ilike', 'in', 'is']
 
 /**
  * Creates a viable SQL where clause from a passed in SQL (from a url "where" param)

--- a/test/filter.js
+++ b/test/filter.js
@@ -67,6 +67,20 @@ test('With an in parameter', t => {
   run('trees', options, 13134, t)
 })
 
+test('With an is parameter', t => {
+  const options = {
+    where: 'Species IS NULL'
+  }
+  run('trees', options, 2872, t)
+})
+
+test('With two is and one and parameters', t => {
+  const options = {
+    where: 'Genus IS NULL AND Street_Direction IS NOT NULL'
+  }
+  run('trees', options, 22, t)
+})
+
 test('With an > parameter', t => {
   const options = {
     where: 'Trunk_Diameter>10'


### PR DESCRIPTION
Currently without the IS command the property will not get nested under the properties =>.
This means IS NULL and IS NOT NULL do not work.