### PR TITLE
fix: covers case where AGOL sends appended 1=1 along with other query fields

### DIFF
--- a/src/where.js
+++ b/src/where.js
@@ -153,7 +153,8 @@ function jsonify (token, next, options) {
   }
   const selector = options.esri ? 'attributes' : 'properties'
   if (next) next = next.toLowerCase()
-  if (OPERATORS.indexOf(next) > -1) return `${leading}${selector}->\`${token.replace(/'|"/g, '')}\`${trailing}`
+  var field = token.replace(/'|"/g, '')
+  if (OPERATORS.indexOf(next) > -1 && field !== '1') return `${leading}${selector}->\`${field}\`${trailing}`
   else return leading + token + trailing
 }
 

--- a/src/where.js
+++ b/src/where.js
@@ -153,7 +153,7 @@ function jsonify (token, next, options) {
   }
   const selector = options.esri ? 'attributes' : 'properties'
   if (next) next = next.toLowerCase()
-  var field = token.replace(/'|"/g, '')
+  const field = token.replace(/'|"/g, '')
   if (OPERATORS.indexOf(next) > -1 && field !== '1') return `${leading}${selector}->\`${field}\`${trailing}`
   else return leading + token + trailing
 }

--- a/test/filter.js
+++ b/test/filter.js
@@ -16,6 +16,13 @@ test('With a where option with multiple statements', t => {
   run('trees', options, 1, t)
 })
 
+test('With a where option with multiple statements with appended 1=1', t => {
+  const options = {
+    where: "Genus like '%Quercus%' AND Street_Name = 'CLAREMONT' AND House_Number < 600 AND Trunk_Diameter = 9 AND 1=1"
+  }
+  run('trees', options, 1, t)
+})
+
 test('With a field that has been uppercased', t => {
   const options = {
     where: "UPPER(Genus) like '%Quercus%'"


### PR DESCRIPTION
We noticed sometimes that AGOL would send 1=1 at the end of a query string with many other query parameters.  When this would happen the field from 1=1 would get converted to properties => 1 and break the query.